### PR TITLE
fix: only request user:email scope from github

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -13,6 +13,7 @@ const options = {
     Providers.GitHub({
       clientId: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      scope: "user:email"
     }),
   ],
   adapter: Adapters.Prisma.Adapter({ prisma }),


### PR DESCRIPTION
- Adds `user:email` scope to GitHub provider for next-auth